### PR TITLE
fix: 皮肤卡片去除overflow-scroll

### DIFF
--- a/src/components/SkinSelect.tsx
+++ b/src/components/SkinSelect.tsx
@@ -93,7 +93,7 @@ export default function SkinSelect({ label, onSave }: SkinSelectProps) {
                           setCurrentSelect?.(item);
                         }}
                       >
-                        <Card className="py-4 overflow-scroll h-36 w-20">
+                        <Card className="py-4 h-36 w-20">
                           <CardBody className="overflow-visible py-2 h-full w-full">
                             <LazyLoadAvatar useAvatar={false} url={item.img} />
                           </CardBody>


### PR DESCRIPTION
卡片强制展示滚动条，在部分设备下会有较宽的无用滚动条展示，比较影响视觉